### PR TITLE
API loading model locally from image container

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ SPLIT_RATIO_1=6.
 SPLIT_RATIO_2=.2
 DATA_SIZE=all
 CHUNK_SIZE=200000
-MODEL_TARGET=gcs
+MODEL_TARGET=local #gcs
 
 # GCP Project
 GCP_PROJECT=waste-sorter-smart-bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 raw_data/
 data/
 models/
+custom/
+project_waste_sorter.egg-info/
 
 .env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM tensorflow/tensorflow:2.10.0
 COPY requirements.txt /requirements.txt
 COPY setup.py /setup.py
 COPY project_waste_sorter /project_waste_sorter
-COPY models /models
+COPY training_outputs /training_outputs
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt

--- a/project_waste_sorter/api/api_file.py
+++ b/project_waste_sorter/api/api_file.py
@@ -1,14 +1,20 @@
 from fastapi import FastAPI, File, UploadFile
+from tensorflow import keras
 from keras.utils import img_to_array
 from keras.applications.vgg16 import preprocess_input
 from project_waste_sorter.ml_logic.registry import *
 from google.cloud import storage
 from io import BytesIO
 from PIL import Image
+from project_waste_sorter.params import *
+import os
 
 app = FastAPI()
 
-app.state.model = load_model()  # Load the model at startup
+local_model_directory = os.path.join(os.path.sep, LOCAL_REGISTRY_PATH, "models")
+model_path = glob.glob(f"{local_model_directory}/*")
+
+app.state.model = keras.models.load_model(model_path) #load_model()  # Load the model at startup
 
 @app.get("/")
 def index():

--- a/project_waste_sorter/params.py
+++ b/project_waste_sorter/params.py
@@ -26,7 +26,7 @@ GAR_MEMORY = os.environ.get("GAR_MEMORY")
 ##################  CONSTANTS  #####################
 LOCAL_DATA_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
 #LOCAL_REGISTRY_PATH =  os.path.join(os.path.expanduser('~'), ".lewagon", "waste_sorter_smart_bin", "training_outputs")
-LOCAL_REGISTRY_PATH =  os.path.join(os.path.sep,"models")
+LOCAL_REGISTRY_PATH =  "training_outputs"
 COLUMN_NAMES_RAW = ['image_base64','y']
 
 # TO MODIFY


### PR DESCRIPTION
- As suggested by Ben, the model will be stored in the container as we are not considering retraining it (for the moment).
- So I modified the Dockerfile in order to COPY into the image a folder called “training_outputs/models” containing the model( For info, I also modified the Dockerfile because it was coping a requirements_prod.txt file instead of the requirements.txt we have for the project)
- So now, in the api_file, instead of calling the “load_model” function to load the model from GCS, the idea is to load it directly from the “training_outputs/models” directory that it is created in the image. (I know that we could still call the load_function with the MODEL_TARGET=local but this makes a supplementary step and for now I want to check it directly like this).
- And here comes my problem : I don’t know why the path to the model file in the image is not correct. I have modified the variable LOCAL_REGISTRY_PATH in params.py but I doesn’t work and I don’t understand why. 
- So we are able to create the image correctly, the API is connected (the root endpoint works well from the image in the container) but the prediction endpoint is not working because (I think) the path to the model file is not correct. 